### PR TITLE
make boss health toggleable

### DIFF
--- a/ahk/Settings.ahk
+++ b/ahk/Settings.ahk
@@ -51,6 +51,7 @@ global PluginOptions := { "AutoFlask"     : { "enabled" : true }
                                             , "speedY"             : 1.0
                                             , "showBeast"          : true
                                             , "showMods"           : false
+                                            , "showBossHealth"     : true
                                             , "showExpedition"     : true
                                             , "ignoredDelveChests" : "Armour|Weapon|Generic|NoDrops|Encounter"
                                             , "ignoredHeistChests" : "Armour|Weapons|Corrupted|Gems|Jewellery|Jewels|QualityCurrency|Talisman|Trinkets|Uniques" }

--- a/plugins/MinimapSymbol.cpp
+++ b/plugins/MinimapSymbol.cpp
@@ -471,7 +471,7 @@ public:
         ignored_entities.clear();
         damage_numbers.clear();
         player = nullptr;
-        expedition_detonated = true;
+        expedition_detonated = false;
     }
 
     void on_area_changed(AreaTemplate* world_area, int hash_code, LocalPlayer* player) {

--- a/plugins/MinimapSymbol.cpp
+++ b/plugins/MinimapSymbol.cpp
@@ -70,6 +70,7 @@ public:
     bool show_minions = true;
     bool show_damage = true;
     bool show_mods = true;
+    bool show_boss_health = true;
     bool show_beast = true;
     bool show_expedition = true;
 
@@ -92,7 +93,7 @@ public:
                                            {L"SuppliesFlares", 0xff0000},
                                            {L"Unique", 0xffff}};
 
-    MinimapSymbol() : PoEPlugin(L"MinimapSymbol", "0.28"),
+    MinimapSymbol() : PoEPlugin(L"MinimapSymbol", "0.29"),
         ignored_delve_chests(L"Armour|Weapon|Generic|NoDrops|Encounter"),
         heist_regex(L"HeistChest(Secondary|RewardRoom(Agility|BruteForce|CounterThaumaturge|Deception|Demolition|Engineering|LockPicking|Perception|TrapDisarmament|))(.*)(Military|Robot|Science|Thug)"),
         ignored_heist_chests(L"Armour|Weapons|Corrupted|Gems|Jewellery|Jewels|QualityCurrency|Talisman|Trinkets|Uniques"),
@@ -114,6 +115,7 @@ public:
         add_property(L"speedX", &speed_x, AhkFloat);
         add_property(L"speedY", &speed_y, AhkFloat);
         add_property(L"showMods", &show_mods, AhkBool);
+        add_property(L"showBossHealth", &show_boss_health, AhkBool);
         add_property(L"showBeast", &show_beast, AhkBool);
         add_property(L"showExpedition", &show_expedition, AhkBool);
 
@@ -180,7 +182,7 @@ public:
                     poe->draw_text(e->name(), x, y + 10, 0xffff52, 0x0c0c0c, 1.0, 1);
                 else if (show_mods)
                     poe->draw_text(e->archnemesis_hint, x, y + 5, 0xffffff, 0x0c0c0c, 1.0, 1);
-            } else if (index == 3) {
+            } else if (show_boss_health && index == 3) {
                 wchar_t buffer[16];
                 swprintf(buffer, L" %.1f %% ", e->saved_life * 100. / e->max_life);
                 poe->draw_text(buffer, x, y - 25, 0xffffff, 0x7f00, 1.0, 1);


### PR DESCRIPTION
Makes boss health toggleable as per multiple feature requests.

Also fixes Expedition overlays only showing up on first run.